### PR TITLE
'barplot' exception handling

### DIFF
--- a/q2_taxa/assets/barplot/src/data.js
+++ b/q2_taxa/assets/barplot/src/data.js
@@ -68,8 +68,16 @@ function _sortDescRelative(a, b, key) {
 }
 
 function _computeTotal(data, keys) {
+  let absentSamples = [];
   for (let i = 0; i < data.length; i += 1) {
     const sample = data[i];
+    try {
+      if (typeof sample === 'undefined') {
+        // Sample dooes not exist / missing
+        absentSamples.push(sample);
+      }
+    }
+    catch (error) {/* ignore logic */}
     let t = 0;
     for (let j = 0; j < keys.length; j += 1) {
       t += sample[keys[j]];


### PR DESCRIPTION
#110 `barplot` should error if any sample IDs in the feature table aren't found in the metadata: Added content to check if there is missing sample data.