### PR TITLE
PERF/BUG: avoid dense representation of the FeatureTable in collapse

### DIFF
--- a/q2_taxa/_method.py
+++ b/q2_taxa/_method.py
@@ -7,12 +7,13 @@
 # ----------------------------------------------------------------------------
 
 import pandas as pd
+import biom
 import qiime2
 
 from ._util import _collapse_table, _get_max_level
 
 
-def collapse(table: pd.DataFrame, taxonomy: pd.Series,
+def collapse(table: biom.Table, taxonomy: pd.Series,
              level: int) -> pd.DataFrame:
     if level < 1:
         raise ValueError('Requested level of %d is too low. Must be greater '

--- a/q2_taxa/_util.py
+++ b/q2_taxa/_util.py
@@ -45,6 +45,7 @@ def _extract_to_level(taxonomy, table):
     # Collapse table at specified level
     for level in range(1, max_obs_lvl + 1):
         collapsed_table = _collapse_table(table, taxonomy, level, max_obs_lvl)
-        collapsed_tables.append(collapsed_table.to_dataframe(dense=True))
+        as_df = collapsed_table.transpose().to_dataframe(dense=True)
+        collapsed_tables.append(as_df)
 
     return collapsed_tables

--- a/q2_taxa/_util.py
+++ b/q2_taxa/_util.py
@@ -12,7 +12,7 @@ def _get_max_level(taxonomy):
 
 
 def _collapse_table(table, taxonomy, level, max_observed_level):
-    table_ids = set(table.columns)
+    table_ids = set(table.ids(axis='observation'))
     taxonomy_ids = set(taxonomy.index)
     missing_ids = table_ids.difference(taxonomy_ids)
     if len(missing_ids) > 0:
@@ -21,15 +21,15 @@ def _collapse_table(table, taxonomy, level, max_observed_level):
 
     table = table.copy()
 
-    def _collapse(tax):
+    def _collapse(id_, md):
+        tax = taxonomy.loc[id_]
         tax = [x.strip() for x in tax.split(';')]
         if len(tax) < max_observed_level:
             padding = ['__'] * (max_observed_level - len(tax))
             tax.extend(padding)
         return ';'.join(tax[:level])
 
-    table.columns = taxonomy.apply(_collapse)[table.columns]
-    return table.groupby(table.columns, axis=1).agg(sum)
+    return table.collapse(_collapse, axis='observation', norm=False)
 
 
 def _extract_to_level(taxonomy, table):

--- a/q2_taxa/_util.py
+++ b/q2_taxa/_util.py
@@ -5,6 +5,8 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
+import pandas as pd
+import biom
 
 
 def _get_max_level(taxonomy):
@@ -36,10 +38,13 @@ def _extract_to_level(taxonomy, table):
     # Assemble the taxonomy data
     max_obs_lvl = _get_max_level(taxonomy)
 
+    if isinstance(table, pd.DataFrame):
+        table = biom.Table(table.T.values, table.columns, table.index)
+
     collapsed_tables = []
     # Collapse table at specified level
     for level in range(1, max_obs_lvl + 1):
         collapsed_table = _collapse_table(table, taxonomy, level, max_obs_lvl)
-        collapsed_tables.append(collapsed_table)
+        collapsed_tables.append(collapsed_table.to_dataframe(dense=True))
 
     return collapsed_tables

--- a/q2_taxa/_util.py
+++ b/q2_taxa/_util.py
@@ -5,8 +5,6 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
-import pandas as pd
-import biom
 
 
 def _get_max_level(taxonomy):

--- a/q2_taxa/_util.py
+++ b/q2_taxa/_util.py
@@ -38,9 +38,6 @@ def _extract_to_level(taxonomy, table):
     # Assemble the taxonomy data
     max_obs_lvl = _get_max_level(taxonomy)
 
-    if isinstance(table, pd.DataFrame):
-        table = biom.Table(table.T.values, table.columns, table.index)
-
     collapsed_tables = []
     # Collapse table at specified level
     for level in range(1, max_obs_lvl + 1):

--- a/q2_taxa/_visualizer.py
+++ b/q2_taxa/_visualizer.py
@@ -11,6 +11,7 @@ import os.path
 import pkg_resources
 import shutil
 
+import biom
 import pandas as pd
 import q2templates
 
@@ -22,13 +23,14 @@ from ._util import _extract_to_level
 TEMPLATES = pkg_resources.resource_filename('q2_taxa', 'assets')
 
 
-def barplot(output_dir: str, table: pd.DataFrame, taxonomy: pd.Series,
+def barplot(output_dir: str, table: biom.Table, taxonomy: pd.Series,
             metadata: Metadata = None) -> None:
 
     if metadata is None:
-        metadata = Metadata(pd.DataFrame({'id': table.index}).set_index('id'))
+        metadata = Metadata(
+            pd.DataFrame({'id': table.ids(axis='sample')}).set_index('id'))
 
-    ids_not_in_metadata = set(table.index) - set(metadata.ids)
+    ids_not_in_metadata = set(table.ids(axis='sample')) - set(metadata.ids)
     if ids_not_in_metadata:
         raise ValueError('Sample IDs found in the table are missing in the '
                          f'metadata: {ids_not_in_metadata!r}.')

--- a/q2_taxa/tests/test_methods.py
+++ b/q2_taxa/tests/test_methods.py
@@ -8,6 +8,8 @@
 
 import unittest
 
+import numpy as np
+import biom
 import pandas as pd
 import pandas.util.testing as pdt
 import qiime2
@@ -38,56 +40,64 @@ class CollapseTests(unittest.TestCase):
         self.assert_index_equal(left.index, right.index)
 
     def test_collapse(self):
-        table = pd.DataFrame([[2.0, 2.0], [1.0, 1.0], [9.0, 8.0], [0.0, 4.0]],
-                             index=['A', 'B', 'C', 'D'],
-                             columns=['feat1', 'feat2'])
+        table = biom.Table(np.array([[2.0, 2.0], [1.0, 1.0], [9.0, 8.0],
+                                     [0.0, 4.0]]),
+                           ['A', 'B', 'C', 'D'],
+                           ['feat1', 'feat2']).transpose()
         taxonomy = pd.Series(['a; b; c', 'a; b; d'],
                              index=['feat1', 'feat2'])
 
         actual = collapse(table, taxonomy, 1)
-        expected = pd.DataFrame([[4.0], [2.0], [17.0], [4.0]],
-                                index=['A', 'B', 'C', 'D'],
-                                columns=['a'])
-        self.assert_data_frame_almost_equal(actual, expected)
+        actual.del_metadata()
+        expected = biom.Table(np.array([[4.0], [2.0], [17.0], [4.0]]),
+                              ['A', 'B', 'C', 'D'],
+                              ['a']).transpose()
+        self.assertEqual(actual, expected)
 
         actual = collapse(table, taxonomy, 2)
-        expected = pd.DataFrame([[4.0], [2.0], [17.0], [4.0]],
-                                index=['A', 'B', 'C', 'D'],
-                                columns=['a;b'])
-        self.assert_data_frame_almost_equal(actual, expected)
+        actual.del_metadata()
+        expected = biom.Table(np.array([[4.0], [2.0], [17.0], [4.0]]),
+                              ['A', 'B', 'C', 'D'],
+                              ['a;b']).transpose()
+        self.assertEqual(actual, expected)
 
         actual = collapse(table, taxonomy, 3)
-        expected = pd.DataFrame([[2.0, 2.0], [1.0, 1.0], [9.0, 8.0],
-                                 [0.0, 4.0]],
-                                index=['A', 'B', 'C', 'D'],
-                                columns=['a;b;c', 'a;b;d'])
-        self.assert_data_frame_almost_equal(actual, expected)
+        actual.del_metadata()
+        expected = biom.Table(np.array([[2.0, 2.0], [1.0, 1.0], [9.0, 8.0],
+                                        [0.0, 4.0]]),
+                              ['A', 'B', 'C', 'D'],
+                              ['a;b;c', 'a;b;d']).transpose()
+        self.assertEqual(actual, expected)
 
     def test_collapse_missing_level(self):
-        table = pd.DataFrame([[2.0, 2.0], [1.0, 1.0], [9.0, 8.0], [0.0, 4.0]],
-                             index=['A', 'B', 'C', 'D'],
-                             columns=['feat1', 'feat2'])
+        table = biom.Table(np.array([[2.0, 2.0], [1.0, 1.0], [9.0, 8.0],
+                                     [0.0, 4.0]]),
+                           ['A', 'B', 'C', 'D'],
+                           ['feat1', 'feat2']).transpose()
         taxonomy = pd.Series(['a; b', 'a; b; d'],
                              index=['feat1', 'feat2'])
 
         actual = collapse(table, taxonomy, 1)
-        expected = pd.DataFrame([[4.0], [2.0], [17.0], [4.0]],
-                                index=['A', 'B', 'C', 'D'],
-                                columns=['a'])
-        self.assert_data_frame_almost_equal(actual, expected)
+        actual.del_metadata()
+        expected = biom.Table(np.array([[4.0], [2.0], [17.0], [4.0]]),
+                              ['A', 'B', 'C', 'D'],
+                              ['a']).transpose()
+        self.assertEqual(actual, expected)
 
         actual = collapse(table, taxonomy, 2)
-        expected = pd.DataFrame([[4.0], [2.0], [17.0], [4.0]],
-                                index=['A', 'B', 'C', 'D'],
-                                columns=['a;b'])
-        self.assert_data_frame_almost_equal(actual, expected)
+        actual.del_metadata()
+        expected = biom.Table(np.array([[4.0], [2.0], [17.0], [4.0]]),
+                              ['A', 'B', 'C', 'D'],
+                              ['a;b']).transpose()
+        self.assertEqual(actual, expected)
 
         actual = collapse(table, taxonomy, 3)
-        expected = pd.DataFrame([[2.0, 2.0], [1.0, 1.0], [9.0, 8.0],
-                                 [0.0, 4.0]],
-                                index=['A', 'B', 'C', 'D'],
-                                columns=['a;b;__', 'a;b;d'])
-        self.assert_data_frame_almost_equal(actual, expected)
+        actual.del_metadata()
+        expected = biom.Table(np.array([[2.0, 2.0], [1.0, 1.0], [9.0, 8.0],
+                                        [0.0, 4.0]]),
+                              ['A', 'B', 'C', 'D'],
+                              ['a;b;__', 'a;b;d']).transpose()
+        self.assertEqual(actual, expected)
 
     def test_collapse_bad_level(self):
         table = pd.DataFrame([[2.0, 2.0], [1.0, 1.0], [9.0, 8.0], [0.0, 4.0]],
@@ -102,12 +112,12 @@ class CollapseTests(unittest.TestCase):
             collapse(table, taxonomy, 0)
 
     def test_collapse_missing_table_ids_in_taxonomy(self):
-        table = pd.DataFrame([[2.0, 2.0],
-                              [1.0, 1.0],
-                              [9.0, 8.0],
-                              [0.0, 4.0]],
-                             index=['A', 'B', 'C', 'D'],
-                             columns=['feat1', 'feat2'])
+        table = biom.Table(np.array([[2.0, 2.0],
+                                     [1.0, 1.0],
+                                     [9.0, 8.0],
+                                     [0.0, 4.0]]),
+                           ['A', 'B', 'C', 'D'],
+                           ['feat1', 'feat2']).transpose()
         taxonomy = pd.Series(['a; b; c', 'a; b; d'],
                              index=['feat1', 'feat3'])
         with self.assertRaisesRegex(ValueError, 'missing.*feat2'):

--- a/q2_taxa/tests/test_visualizer.py
+++ b/q2_taxa/tests/test_visualizer.py
@@ -10,6 +10,8 @@ import os
 import tempfile
 import unittest
 
+import biom
+import numpy as np
 import pandas as pd
 import qiime2
 
@@ -19,10 +21,10 @@ from q2_taxa import barplot
 class BarplotTests(unittest.TestCase):
 
     def setUp(self):
-        self.table = pd.DataFrame([[2.0, 2.0], [1.0, 1.0], [9.0, 8.0],
-                                  [0.0, 4.0]],
-                                  index=['A', 'B', 'C', 'D'],
-                                  columns=['feat1', 'feat2'])
+        self.table = biom.Table(np.array([[2.0, 2.0], [1.0, 1.0], [9.0, 8.0],
+                                          [0.0, 4.0]]),
+                                ['A', 'B', 'C', 'D'],
+                                ['feat1', 'feat2']).transpose()
         self.taxonomy = pd.Series(['a; b; c', 'a; b; d'],
                                   index=['feat1', 'feat2'])
 


### PR DESCRIPTION
This pull request fixes #135, avoiding a dense representation of the FeatureTable when performing a taxonomy collapse.

