### PR TITLE
enable generation of barplot from relative frequency table

### DIFF
--- a/q2_taxa/plugin_setup.py
+++ b/q2_taxa/plugin_setup.py
@@ -11,7 +11,7 @@ import qiime2.plugin
 import q2_taxa
 
 from q2_types.feature_data import FeatureData, Taxonomy, Sequence
-from q2_types.feature_table import FeatureTable, Frequency
+from q2_types.feature_table import FeatureTable, Frequency, RelativeFrequency
 
 
 from . import barplot, collapse, filter_table, filter_seqs
@@ -176,7 +176,7 @@ plugin.visualizers.register_function(
     function=barplot,
     inputs={
         'taxonomy': FeatureData[Taxonomy],
-        'table': FeatureTable[Frequency]
+        'table': FeatureTable[Frequency] | FeatureTable[RelativeFrequency]
     },
     parameters={'metadata': qiime2.plugin.Metadata},
     input_descriptions={


### PR DESCRIPTION
This enables generation of a taxonomy barplot from `FeatureTable[RelativeFrequency]`, in addition to from `FeatureTable[Frequency]`. I did some spot checks of the values in each - both linked below. The patterns match for the most part, but I do observe some different sorting of the taxa in the legend. For example, compare `Thermi` versus `Tenericutes` in the legends below - generated from `FeatureTable[RelativeFrequency]` on the left, and `FeatureTable[Frequency]` on the right. 

![Screen Shot 2022-08-17 at 11 24 34 AM](https://user-images.githubusercontent.com/192372/185216442-89c2d7c8-fcaa-456e-b795-8650d2a2659f.png)


Without additional changes, we're still computing relative frequency from the `FeatureTable[RelativeFrequency]` input in the javascript code. I suspect that may be leading to rounding differences that make subtle differences in the overall abundances (and therefore order of appearance) of the taxa in the plot. 

Given this difference in the output, and the fact that we're already past the deadline for pull requests for 2022.8, I'm going to leave this as a draft PR and will improving the handling here so relative frequencies aren't computed again when a `RelativeFrequency` table is provided as input. I'll work on this for the next release. 

[Taxa barplot generated from `FeatureTable[RelativeFrequency]`](https://view.qiime2.org/visualization/?type=html&src=https%3A%2F%2Fdl.dropbox.com%2Fs%2Fu8wlq5za8amzvfh%2Fbp-rf.qzv%3Fdl%3D1)
[Taxa barplot generated from `FeatureTable[Frequency]`](https://view.qiime2.org/visualization/?type=html&src=https%3A%2F%2Fdl.dropbox.com%2Fs%2Fg67jqiv0l0hukar%2Fbp-freq.qzv%3Fdl%3D1)
