### PR TITLE
barplot: make taxonomy optional

### DIFF
--- a/q2_taxa/_method.py
+++ b/q2_taxa/_method.py
@@ -20,14 +20,15 @@ def collapse(table: biom.Table, taxonomy: pd.Series,
                          'than or equal to 1.' % level)
 
     # Assemble the taxonomy data
-    max_observed_level = _get_max_level(taxonomy)
+    max_observed_level = _get_max_level(taxonomy, level_delimiter=';')
 
     if level > max_observed_level:
         raise ValueError('Requested level of %d is larger than the maximum '
                          'level available in taxonomy data (%d).' %
                          (level, max_observed_level))
 
-    return _collapse_table(table, taxonomy, level, max_observed_level)
+    return _collapse_table(
+        table, taxonomy, level, max_observed_level, level_delimiter=';')
 
 
 def _ids_to_keep_from_taxonomy(feature_ids, taxonomy, include, exclude,

--- a/q2_taxa/_method.py
+++ b/q2_taxa/_method.py
@@ -20,15 +20,14 @@ def collapse(table: biom.Table, taxonomy: pd.Series,
                          'than or equal to 1.' % level)
 
     # Assemble the taxonomy data
-    max_observed_level = _get_max_level(taxonomy, level_delimiter=';')
+    max_observed_level = _get_max_level(taxonomy)
 
     if level > max_observed_level:
         raise ValueError('Requested level of %d is larger than the maximum '
                          'level available in taxonomy data (%d).' %
                          (level, max_observed_level))
 
-    return _collapse_table(
-        table, taxonomy, level, max_observed_level, level_delimiter=';')
+    return _collapse_table(table, taxonomy, level, max_observed_level)
 
 
 def _ids_to_keep_from_taxonomy(feature_ids, taxonomy, include, exclude,

--- a/q2_taxa/_util.py
+++ b/q2_taxa/_util.py
@@ -40,7 +40,11 @@ def _extract_to_level(taxonomy, table):
     # Collapse table at specified level
     for level in range(1, max_obs_lvl + 1):
         collapsed_table = _collapse_table(table, taxonomy, level, max_obs_lvl)
-        as_df = collapsed_table.transpose().to_dataframe(dense=True)
+        as_df = _biom_to_df(collapsed_table)
         collapsed_tables.append(as_df)
 
     return collapsed_tables
+
+
+def _biom_to_df(table):
+    return table.transpose().to_dataframe(dense=True)

--- a/q2_taxa/_util.py
+++ b/q2_taxa/_util.py
@@ -7,12 +7,11 @@
 # ----------------------------------------------------------------------------
 
 
-def _get_max_level(taxonomy, level_delimiter):
-    return taxonomy.apply(lambda x: len(x.split(level_delimiter))).max()
+def _get_max_level(taxonomy):
+    return taxonomy.apply(lambda x: len(x.split(';'))).max()
 
 
-def _collapse_table(table, taxonomy, level, max_observed_level,
-                    level_delimiter):
+def _collapse_table(table, taxonomy, level, max_observed_level):
     table_ids = set(table.ids(axis='observation'))
     taxonomy_ids = set(taxonomy.index)
     missing_ids = table_ids.difference(taxonomy_ids)
@@ -22,26 +21,25 @@ def _collapse_table(table, taxonomy, level, max_observed_level,
 
     table = table.copy()
 
-    def _collapse(id_, md, level_delimiter=level_delimiter):
+    def _collapse(id_, md):
         tax = taxonomy.loc[id_]
-        tax = [x.strip() for x in tax.split(level_delimiter)]
+        tax = [x.strip() for x in tax.split(';')]
         if len(tax) < max_observed_level:
             padding = ['__'] * (max_observed_level - len(tax))
             tax.extend(padding)
-        return level_delimiter.join(tax[:level])
+        return ';'.join(tax[:level])
 
     return table.collapse(_collapse, axis='observation', norm=False)
 
 
-def _extract_to_level(taxonomy, table, level_delimiter):
+def _extract_to_level(taxonomy, table):
     # Assemble the taxonomy data
-    max_obs_lvl = _get_max_level(taxonomy, level_delimiter)
+    max_obs_lvl = _get_max_level(taxonomy)
 
     collapsed_tables = []
     # Collapse table at specified level
     for level in range(1, max_obs_lvl + 1):
-        collapsed_table = _collapse_table(
-            table, taxonomy, level, max_obs_lvl, level_delimiter)
+        collapsed_table = _collapse_table(table, taxonomy, level, max_obs_lvl)
         as_df = _biom_to_df(collapsed_table)
         collapsed_tables.append(as_df)
 

--- a/q2_taxa/_visualizer.py
+++ b/q2_taxa/_visualizer.py
@@ -23,7 +23,7 @@ from ._util import _extract_to_level
 TEMPLATES = pkg_resources.resource_filename('q2_taxa', 'assets')
 
 
-def barplot(output_dir: str, table: biom.Table, taxonomy: pd.Series,
+def barplot(output_dir: str, table: biom.Table, taxonomy: pd.Series = None,
             metadata: Metadata = None) -> None:
 
     if metadata is None:
@@ -34,6 +34,10 @@ def barplot(output_dir: str, table: biom.Table, taxonomy: pd.Series,
     if ids_not_in_metadata:
         raise ValueError('Sample IDs found in the table are missing in the '
                          f'metadata: {ids_not_in_metadata!r}.')
+
+    if taxonomy is None:
+        _ids = table.ids('observation')
+        taxonomy = pd.Series(_ids, index=_ids)
 
     num_metadata_cols = metadata.column_count
     metadata = metadata.to_dataframe()

--- a/q2_taxa/_visualizer.py
+++ b/q2_taxa/_visualizer.py
@@ -24,7 +24,7 @@ TEMPLATES = pkg_resources.resource_filename('q2_taxa', 'assets')
 
 
 def barplot(output_dir: str, table: biom.Table, taxonomy: pd.Series = None,
-            metadata: Metadata = None, level_delimiter: str = None) -> None:
+            metadata: Metadata = None, parse_ids: bool = False) -> None:
 
     if metadata is None:
         metadata = Metadata(
@@ -37,31 +37,16 @@ def barplot(output_dir: str, table: biom.Table, taxonomy: pd.Series = None,
 
     collapse = True
     if taxonomy is None:
-        if level_delimiter is None:
+        _ids = table.ids('observation')
+        taxonomy = pd.Series(_ids, index=_ids)
+        if not parse_ids:
             collapse = False
-        else:
-            _ids = table.ids('observation')
-            taxonomy = pd.Series(_ids, index=_ids)
-    # Note: if a taxonomy is passed we will default to a semicolon delimiter.
-    # This feels slightly dirty, but seems like a way to have our cake and eat
-    # it too. i.e., we can add the level_delimiter parameter AND make the
-    # default None (so that feature IDs are not automatically parsed) without
-    # breaking the current behavior of barplot.
-    # The user can override this behavior by just setting an arbitrary
-    # delimiter (e.g., |) if they really want to make a barplot of a taxonomy
-    # without splitting into levels, which feels like an edge case that might
-    # not ever actually happen.
-    else:
-        if level_delimiter is None:
-            level_delimiter = ';'
 
     num_metadata_cols = metadata.column_count
     metadata = metadata.to_dataframe()
     jsonp_files, csv_files = [], []
     if collapse:
-        print(level_delimiter)
-        collapsed_tables = _extract_to_level(
-            taxonomy, table, level_delimiter=level_delimiter)
+        collapsed_tables = _extract_to_level(taxonomy, table)
     else:
         collapsed_tables = [_biom_to_df(table)]
 

--- a/q2_taxa/_visualizer.py
+++ b/q2_taxa/_visualizer.py
@@ -24,7 +24,7 @@ TEMPLATES = pkg_resources.resource_filename('q2_taxa', 'assets')
 
 
 def barplot(output_dir: str, table: biom.Table, taxonomy: pd.Series = None,
-            metadata: Metadata = None, parse_ids: bool = False) -> None:
+            metadata: Metadata = None, level_delimiter: str = None) -> None:
 
     if metadata is None:
         metadata = Metadata(
@@ -37,10 +37,12 @@ def barplot(output_dir: str, table: biom.Table, taxonomy: pd.Series = None,
 
     collapse = True
     if taxonomy is None:
-        _ids = table.ids('observation')
-        taxonomy = pd.Series(_ids, index=_ids)
-        if not parse_ids:
+        if level_delimiter is None:
             collapse = False
+        else:
+            _ids = table.ids('observation')
+            ranks = [r.replace(level_delimiter, ';') for r in _ids]
+            taxonomy = pd.Series(ranks, index=_ids)
 
     num_metadata_cols = metadata.column_count
     metadata = metadata.to_dataframe()

--- a/q2_taxa/_visualizer.py
+++ b/q2_taxa/_visualizer.py
@@ -24,7 +24,7 @@ TEMPLATES = pkg_resources.resource_filename('q2_taxa', 'assets')
 
 
 def barplot(output_dir: str, table: biom.Table, taxonomy: pd.Series = None,
-            metadata: Metadata = None, parse_ids: bool = False) -> None:
+            metadata: Metadata = None, level_delimiter: str = None) -> None:
 
     if metadata is None:
         metadata = Metadata(
@@ -37,16 +37,31 @@ def barplot(output_dir: str, table: biom.Table, taxonomy: pd.Series = None,
 
     collapse = True
     if taxonomy is None:
-        _ids = table.ids('observation')
-        taxonomy = pd.Series(_ids, index=_ids)
-        if not parse_ids:
+        if level_delimiter is None:
             collapse = False
+        else:
+            _ids = table.ids('observation')
+            taxonomy = pd.Series(_ids, index=_ids)
+    # Note: if a taxonomy is passed we will default to a semicolon delimiter.
+    # This feels slightly dirty, but seems like a way to have our cake and eat
+    # it too. i.e., we can add the level_delimiter parameter AND make the
+    # default None (so that feature IDs are not automatically parsed) without
+    # breaking the current behavior of barplot.
+    # The user can override this behavior by just setting an arbitrary
+    # delimiter (e.g., |) if they really want to make a barplot of a taxonomy
+    # without splitting into levels, which feels like an edge case that might
+    # not ever actually happen.
+    else:
+        if level_delimiter is None:
+            level_delimiter = ';'
 
     num_metadata_cols = metadata.column_count
     metadata = metadata.to_dataframe()
     jsonp_files, csv_files = [], []
     if collapse:
-        collapsed_tables = _extract_to_level(taxonomy, table)
+        print(level_delimiter)
+        collapsed_tables = _extract_to_level(
+            taxonomy, table, level_delimiter=level_delimiter)
     else:
         collapsed_tables = [_biom_to_df(table)]
 

--- a/q2_taxa/plugin_setup.py
+++ b/q2_taxa/plugin_setup.py
@@ -13,7 +13,6 @@ import q2_taxa
 from q2_types.feature_data import FeatureData, Taxonomy, Sequence
 from q2_types.feature_table import FeatureTable, Frequency
 
-
 from . import barplot, collapse, filter_table, filter_seqs
 import q2_taxa._examples as ex
 
@@ -182,7 +181,8 @@ plugin.visualizers.register_function(
         'taxonomy': FeatureData[Taxonomy],
         'table': FeatureTable[Frequency]
     },
-    parameters={'metadata': qiime2.plugin.Metadata},
+    parameters={'metadata': qiime2.plugin.Metadata,
+                'parse_ids': qiime2.plugin.Bool},
     input_descriptions={
         'taxonomy': ('Taxonomic annotations for features in the provided '
                      'feature table. All features in the feature table must '
@@ -191,7 +191,13 @@ plugin.visualizers.register_function(
                      'will be ignored. If no taxonomy is provided, the '
                      'feature IDs will be used as labels.'),
         'table': 'Feature table to visualize at various taxonomic levels.'},
-    parameter_descriptions={'metadata': 'The sample metadata.'},
+    parameter_descriptions={
+        'metadata': 'The sample metadata.',
+        'parse_ids': 'Attempt to parse hierarchical taxonomic information '
+                     'from feature IDs. Taxonomic ranks are inferred from '
+                     'semicolon-delimited IDs. This parameter is ignored if '
+                     'a taxonomy is provided as input.'
+        },
     name='Visualize taxonomy with an interactive bar plot',
     description='This visualizer produces an interactive barplot visualization'
                 ' of taxonomies. Interactive features include multi-level '

--- a/q2_taxa/plugin_setup.py
+++ b/q2_taxa/plugin_setup.py
@@ -182,7 +182,7 @@ plugin.visualizers.register_function(
         'table': FeatureTable[Frequency]
     },
     parameters={'metadata': qiime2.plugin.Metadata,
-                'parse_ids': qiime2.plugin.Bool},
+                'level_delimiter': qiime2.plugin.Str},
     input_descriptions={
         'taxonomy': ('Taxonomic annotations for features in the provided '
                      'feature table. All features in the feature table must '
@@ -193,10 +193,10 @@ plugin.visualizers.register_function(
         'table': 'Feature table to visualize at various taxonomic levels.'},
     parameter_descriptions={
         'metadata': 'The sample metadata.',
-        'parse_ids': 'Attempt to parse hierarchical taxonomic information '
-                     'from feature IDs. Taxonomic ranks are inferred from '
-                     'semicolon-delimited IDs. This parameter is ignored if '
-                     'a taxonomy is provided as input.'
+        'level_delimiter': 'Attempt to parse hierarchical taxonomic '
+                           'information from feature IDs by separating '
+                           'levels with this character. This parameter '
+                           'is ignored if a taxonomy is provided as input.'
         },
     name='Visualize taxonomy with an interactive bar plot',
     description='This visualizer produces an interactive barplot visualization'

--- a/q2_taxa/plugin_setup.py
+++ b/q2_taxa/plugin_setup.py
@@ -182,7 +182,7 @@ plugin.visualizers.register_function(
         'table': FeatureTable[Frequency]
     },
     parameters={'metadata': qiime2.plugin.Metadata,
-                'parse_ids': qiime2.plugin.Bool},
+                'level_delimiter': qiime2.plugin.Str},
     input_descriptions={
         'taxonomy': ('Taxonomic annotations for features in the provided '
                      'feature table. All features in the feature table must '
@@ -193,10 +193,17 @@ plugin.visualizers.register_function(
         'table': 'Feature table to visualize at various taxonomic levels.'},
     parameter_descriptions={
         'metadata': 'The sample metadata.',
-        'parse_ids': 'Attempt to parse hierarchical taxonomic information '
-                     'from feature IDs. Taxonomic ranks are inferred from '
-                     'semicolon-delimited IDs. This parameter is ignored if '
-                     'a taxonomy is provided as input.'
+        'level_delimiter': 'The delimiter that separates taxonomic ranks in '
+                           'the provided taxonomy. If no taxonomy is provided '
+                           'and a level_delimiter is passed, it will attempt '
+                           'to parse hierarchical taxonomic information from '
+                           'the feature ID labels. If no level_delimiter is '
+                           'provided and a taxonomy is passed, simicolon (;) '
+                           'level delimiters will be assumed by default, but '
+                           'this can be disabled by inputting a false level '
+                           'delimiter. If no taxonomy is provided and no '
+                           'delimiter is provided, feature IDs will not be '
+                           'separated into different taxonomic ranks.'
         },
     name='Visualize taxonomy with an interactive bar plot',
     description='This visualizer produces an interactive barplot visualization'

--- a/q2_taxa/plugin_setup.py
+++ b/q2_taxa/plugin_setup.py
@@ -188,7 +188,8 @@ plugin.visualizers.register_function(
                      'feature table. All features in the feature table must '
                      'have a corresponding taxonomic annotation. Taxonomic '
                      'annotations that are not present in the feature table '
-                     'will be ignored.'),
+                     'will be ignored. If no taxonomy is provided, the '
+                     'feature IDs will be used as labels.'),
         'table': 'Feature table to visualize at various taxonomic levels.'},
     parameter_descriptions={'metadata': 'The sample metadata.'},
     name='Visualize taxonomy with an interactive bar plot',

--- a/q2_taxa/plugin_setup.py
+++ b/q2_taxa/plugin_setup.py
@@ -182,7 +182,7 @@ plugin.visualizers.register_function(
         'table': FeatureTable[Frequency]
     },
     parameters={'metadata': qiime2.plugin.Metadata,
-                'level_delimiter': qiime2.plugin.Str},
+                'parse_ids': qiime2.plugin.Bool},
     input_descriptions={
         'taxonomy': ('Taxonomic annotations for features in the provided '
                      'feature table. All features in the feature table must '
@@ -193,17 +193,10 @@ plugin.visualizers.register_function(
         'table': 'Feature table to visualize at various taxonomic levels.'},
     parameter_descriptions={
         'metadata': 'The sample metadata.',
-        'level_delimiter': 'The delimiter that separates taxonomic ranks in '
-                           'the provided taxonomy. If no taxonomy is provided '
-                           'and a level_delimiter is passed, it will attempt '
-                           'to parse hierarchical taxonomic information from '
-                           'the feature ID labels. If no level_delimiter is '
-                           'provided and a taxonomy is passed, simicolon (;) '
-                           'level delimiters will be assumed by default, but '
-                           'this can be disabled by inputting a false level '
-                           'delimiter. If no taxonomy is provided and no '
-                           'delimiter is provided, feature IDs will not be '
-                           'separated into different taxonomic ranks.'
+        'parse_ids': 'Attempt to parse hierarchical taxonomic information '
+                     'from feature IDs. Taxonomic ranks are inferred from '
+                     'semicolon-delimited IDs. This parameter is ignored if '
+                     'a taxonomy is provided as input.'
         },
     name='Visualize taxonomy with an interactive bar plot',
     description='This visualizer produces an interactive barplot visualization'

--- a/q2_taxa/tests/test_visualizer.py
+++ b/q2_taxa/tests/test_visualizer.py
@@ -91,7 +91,7 @@ class BarplotTests(unittest.TestCase):
     def test_barplot_collapsed_table(self):
         with tempfile.TemporaryDirectory() as output_dir:
             collapsed_table = collapse(self.table, self.taxonomy, 3)
-            barplot(output_dir, collapsed_table, parse_ids=True)
+            barplot(output_dir, collapsed_table, level_delimiter=';')
             # if level three tables exist, the taxonomy was parsed
             # correctly from the collapsed table.
             csv_lvl3_fp = os.path.join(output_dir, 'level-3.csv')

--- a/q2_taxa/tests/test_visualizer.py
+++ b/q2_taxa/tests/test_visualizer.py
@@ -91,7 +91,7 @@ class BarplotTests(unittest.TestCase):
     def test_barplot_collapsed_table(self):
         with tempfile.TemporaryDirectory() as output_dir:
             collapsed_table = collapse(self.table, self.taxonomy, 3)
-            barplot(output_dir, collapsed_table)
+            barplot(output_dir, collapsed_table, parse_ids=True)
             # if level three tables exist, the taxonomy was parsed
             # correctly from the collapsed table.
             csv_lvl3_fp = os.path.join(output_dir, 'level-3.csv')

--- a/q2_taxa/tests/test_visualizer.py
+++ b/q2_taxa/tests/test_visualizer.py
@@ -91,7 +91,7 @@ class BarplotTests(unittest.TestCase):
     def test_barplot_collapsed_table(self):
         with tempfile.TemporaryDirectory() as output_dir:
             collapsed_table = collapse(self.table, self.taxonomy, 3)
-            barplot(output_dir, collapsed_table, level_delimiter=';')
+            barplot(output_dir, collapsed_table, parse_ids=True)
             # if level three tables exist, the taxonomy was parsed
             # correctly from the collapsed table.
             csv_lvl3_fp = os.path.join(output_dir, 'level-3.csv')


### PR DESCRIPTION
fixes #116 and #108 

This PR makes `FeatureData[Taxonomy]` an optional input to `barplot`. In this case, feature labels are parsed from the feature IDs (either single-level, e.g., ASV IDs, or semicolon-delimited for multi-level)

In practice, this means that various other use cases are possible, e.g.,:
1. input a collapsed table. Taxonomy is parsed from feature IDs.
2. input an ASV/OTU table to look at ASV frequencies in a barplot.

I tested both of these use cases (and added appropriate unit tests). To fully validate, I ran the moving pictures tutorial and made barplots on the collapsed table. The output visualizations are identical.