### PR TITLE
Ids to taxonomy

### DIFF
--- a/q2_taxa/__init__.py
+++ b/q2_taxa/__init__.py
@@ -6,7 +6,7 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
-from ._method import collapse, filter_table, filter_seqs
+from ._method import collapse, ids_to_taxonomy, filter_table, filter_seqs
 from ._visualizer import barplot, barplot2
 
 try:
@@ -14,4 +14,5 @@ try:
 except ModuleNotFoundError:
     __version__ = '0.0.0+notfound'
 
-__all__ = ['barplot', 'barplot2', 'collapse', 'filter_table', 'filter_seqs']
+__all__ = ['barplot', 'barplot2', 'collapse', 'ids_to_taxonomy',
+           'filter_table', 'filter_seqs']

--- a/q2_taxa/__init__.py
+++ b/q2_taxa/__init__.py
@@ -6,7 +6,9 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
-from ._method import collapse, ids_to_taxonomy, filter_table, filter_seqs
+from ._method import (
+    collapse, feature_ids_to_taxonomy, filter_table, filter_seqs
+)
 from ._visualizer import barplot, barplot2
 
 try:
@@ -14,5 +16,5 @@ try:
 except ModuleNotFoundError:
     __version__ = '0.0.0+notfound'
 
-__all__ = ['barplot', 'barplot2', 'collapse', 'ids_to_taxonomy',
+__all__ = ['barplot', 'barplot2', 'collapse', 'feature_ids_to_taxonomy',
            'filter_table', 'filter_seqs']

--- a/q2_taxa/_method.py
+++ b/q2_taxa/_method.py
@@ -38,7 +38,7 @@ def _format_invalid_ids(ids: list[str], max_examples: int = 5):
     return f'{len(ids)} feature IDs. Examples: {examples}'
 
 
-def ids_to_taxonomy(
+def feature_ids_to_taxonomy(
     table: biom.Table,
     delimiter: str = ';',
     strict: bool = True,

--- a/q2_taxa/_method.py
+++ b/q2_taxa/_method.py
@@ -58,9 +58,9 @@ def ids_to_taxonomy(
     strict : bool
         Whether to parse the feature IDs in strict mode. If True, then no
         occurences of semicolons are allowed in the to-be-converted IDs,
-        all IDs must contain `delimiter`, and no empty levels are allowed in
-        the converted taxonomic string. If False, none of these conditions are
-        enforced.
+        at least one feature ID must contain `delimiter`, and no empty levels
+        are allowed in the converted taxonomic string. If False, none of these
+        conditions are enforced.
     semicolon_replacement : str
         The character to use to replace semicolons before replacing
         occurences of `delimiter` with semicolons.
@@ -85,14 +85,13 @@ def ids_to_taxonomy(
                 f'{_format_invalid_ids(semicolon_containing_ids)}.'
             )
 
-        missing_delimiter_ids = [
-            id_ for id_ in feature_ids if delimiter not in id_
+        ids_with_delimiter = [
+            id_ for id_ in feature_ids if delimiter in id_
         ]
-        if missing_delimiter_ids:
+        if not ids_with_delimiter:
             raise ValueError(
-                'Strict parsing requires every feature ID to contain the '
-                f'delimiter {delimiter}. Found '
-                f'{_format_invalid_ids(missing_delimiter_ids)}.'
+                'Strict parsing requires at least one feature ID to contain '
+                f'the delimiter {delimiter}. Found none.'
             )
 
         empty_level_ids = [

--- a/q2_taxa/_method.py
+++ b/q2_taxa/_method.py
@@ -42,7 +42,7 @@ def ids_to_taxonomy(
     table: biom.Table,
     delimiter: str = ';',
     strict: bool = True,
-    semicolon_replacement: str = ':',
+    semicolon_replacement: str | None = None,
 ) -> pd.DataFrame:
     '''
     Convert the feature IDs of `table` into a taxonomy that maps those
@@ -110,7 +110,19 @@ def ids_to_taxonomy(
         taxa = []
         empty_level_ids = []
         for id_ in feature_ids:
-            if delimiter != ';':
+            if delimiter != ';' and ';' in id_:
+                if semicolon_replacement is None:
+                    raise ValueError(
+                        'One or more semicolons detected in the following '
+                        f'id: "{id_}", and no `semicolon_replacement` was '
+                        'specified.'
+                    )
+                if semicolon_replacement == ';':
+                    raise ValueError(
+                        'The `semicolon_replacement` parameter can not be '
+                        'a semicolon.'
+                    )
+
                 parsed_id = id_.replace(';', semicolon_replacement)
             else:
                 parsed_id = id_

--- a/q2_taxa/_method.py
+++ b/q2_taxa/_method.py
@@ -30,6 +30,117 @@ def collapse(table: biom.Table, taxonomy: pd.Series,
     return _collapse_table(table, taxonomy, level, max_observed_level)
 
 
+def _format_invalid_ids(ids: list[str], max_examples: int = 5):
+    examples = ', '.join(repr(id_) for id_ in ids[:max_examples])
+    if len(ids) > max_examples:
+        examples = f'{examples}, ...'
+
+    return f'{len(ids)} feature IDs. Examples: {examples}'
+
+
+def ids_to_taxonomy(
+    table: biom.Table,
+    delimiter: str = ';',
+    strict: bool = True,
+    semicolon_replacement: str = ':',
+) -> pd.DataFrame:
+    '''
+    Convert the feature IDs of `table` into a taxonomy that maps those
+    feature IDs to the typical semicolon representation. No confidence column
+    is stored in the taxonomy.
+
+    Parameters
+    ----------
+    table : biom.Table
+        The table containing the feature IDs to be parsed into a taxonomy.
+    delimiter : str
+        The character(s) that delimit taxonomic levels in the feature IDs.
+    strict : bool
+        Whether to parse the feature IDs in strict mode. If True, then no
+        occurences of semicolons are allowed in the to-be-converted IDs,
+        all IDs must contain `delimiter`, and no empty levels are allowed in
+        the converted taxonomic string. If False, none of these conditions are
+        enforced.
+    semicolon_replacement : str
+        The character to use to replace semicolons before replacing
+        occurences of `delimiter` with semicolons.
+
+    Returns
+    --------
+    pd.DataFrame
+        The taxonomy parsed from the table's feature IDs with the Taxon column
+        using the typical semicolon delimitation.
+    '''
+    if delimiter == '':
+        raise ValueError('The `delimiter` must not be empty.')
+
+    feature_ids = list(table.ids(axis='observation'))
+
+    if strict:
+        semicolon_containing_ids = [id_ for id_ in feature_ids if ';' in id_]
+        if delimiter != ';' and semicolon_containing_ids:
+            raise ValueError(
+                f'Strict parsing with delimiter {delimiter} does not allow '
+                'feature IDs that already contain ";". Found '
+                f'{_format_invalid_ids(semicolon_containing_ids)}.'
+            )
+
+        missing_delimiter_ids = [
+            id_ for id_ in feature_ids if delimiter not in id_
+        ]
+        if missing_delimiter_ids:
+            raise ValueError(
+                'Strict parsing requires every feature ID to contain the '
+                f'delimiter {delimiter}. Found '
+                f'{_format_invalid_ids(missing_delimiter_ids)}.'
+            )
+
+        empty_level_ids = [
+            id_ for id_ in feature_ids if '' in id_.split(delimiter)
+        ]
+        if empty_level_ids:
+            raise ValueError(
+                'Strict parsing found empty taxonomic levels after splitting '
+                f'on delimiter {delimiter}. Found '
+                f'{_format_invalid_ids(empty_level_ids)}'
+            )
+
+        taxa = [';'.join(id_.split(delimiter)) for id_ in feature_ids]
+
+    else:
+        taxa = []
+        empty_level_ids = []
+        for id_ in feature_ids:
+            if delimiter != ';':
+                parsed_id = id_.replace(';', semicolon_replacement)
+            else:
+                parsed_id = id_
+
+            levels = parsed_id.split(delimiter)
+            non_empty_levels = [level for level in levels if level != '']
+            if not non_empty_levels:
+                empty_level_ids.append(id_)
+            else:
+                taxa.append(';'.join(non_empty_levels))
+
+        if empty_level_ids:
+            raise ValueError(
+                'Unable to construct non-empty taxonomy strings for '
+                f'{_format_invalid_ids(empty_level_ids)}. After semicolon '
+                f'replacement and splitting on delimiter {delimiter}, '
+                'all parsed levels were empty. This can occur if a feature ID '
+                'was empty to begin with or contained only semicolons and/or '
+                'delimiters.'
+            )
+
+    taxonomy = pd.DataFrame(
+        {'Taxon': taxa},
+        index=pd.Index(feature_ids, name='Feature ID', dtype=object)
+    )
+
+    return taxonomy
+
+
 def _ids_to_keep_from_taxonomy(feature_ids, taxonomy, include, exclude,
                                query_delimiter, mode):
     if include is None and exclude is None:

--- a/q2_taxa/plugin_setup.py
+++ b/q2_taxa/plugin_setup.py
@@ -15,7 +15,8 @@ from q2_types.feature_table import (
     FeatureTable, Frequency, RelativeFrequency, PresenceAbsence
 )
 
-from . import barplot, barplot2, collapse, filter_table, filter_seqs
+from . import (barplot, barplot2, collapse, ids_to_taxonomy, filter_table,
+               filter_seqs)
 import q2_taxa._examples as ex
 
 T1 = qiime2.plugin.TypeMatch([Frequency, PresenceAbsence])
@@ -64,6 +65,54 @@ plugin.methods.register_function(
     examples={
         'collapse': ex.collapse_example,
     },
+)
+
+plugin.methods.register_function(
+    function=ids_to_taxonomy,
+    inputs={
+        'table': FeatureTable[Frequency | RelativeFrequency | PresenceAbsence]
+    },
+    parameters={
+        'delimiter': qiime2.plugin.Str,
+        'strict': qiime2.plugin.Bool,
+        'semicolon_replacement': qiime2.plugin.Str,
+    },
+    outputs=[('taxonomy', FeatureData[Taxonomy])],
+    input_descriptions={
+        'table': (
+            'The table containing the feature IDs to be parsed into a '
+            'taxonomy.'
+        )
+    },
+    parameter_descriptions={
+        'delimiter': (
+            'The character(s) that delimit taxonomic levels in the feature '
+            'IDs.'
+        ),
+        'strict': (
+            'Whether to parse the feature IDs in strict mode. If True, then '
+            'no occurences of semicolons are allowed in the feature IDs, all '
+            'IDs must contain `delimiter`, and no empty levels are allowed in '
+            'the converted taxonomic strings. If False, none of these '
+            'conditions are enforced.'
+        ),
+        'semicolon_replacement': (
+            'The character to use to replace semicolons before replacing '
+            'occurences of `delimiter` with semicolons. Ignored if `strict` '
+            'parsing is enabled.'
+        )
+    },
+    output_descriptions={
+        'taxonomy': (
+            'The taxonomy parsed from the table\'s feature IDs with the Taxon '
+            'column using the typical semicolon delimitation.'
+        )
+    },
+    name='Create taxonomy from hierarchical feature IDs.',
+    description=(
+        'This method converts feature IDs into taxonomy strings by splitting '
+        'IDs on a delimiter and joining levels with semicolons.'
+    )
 )
 
 plugin.methods.register_function(

--- a/q2_taxa/plugin_setup.py
+++ b/q2_taxa/plugin_setup.py
@@ -12,7 +12,8 @@ import q2_taxa
 
 from q2_types.feature_data import FeatureData, Taxonomy, Sequence
 from q2_types.feature_table import (
-    FeatureTable, Frequency, RelativeFrequency, PresenceAbsence
+    FeatureTable, Frequency, RelativeFrequency, PresenceAbsence,
+    Composition
 )
 
 from . import (barplot, barplot2, collapse, ids_to_taxonomy, filter_table,
@@ -70,7 +71,9 @@ plugin.methods.register_function(
 plugin.methods.register_function(
     function=ids_to_taxonomy,
     inputs={
-        'table': FeatureTable[Frequency | RelativeFrequency | PresenceAbsence]
+        'table': FeatureTable[
+            Frequency | RelativeFrequency | PresenceAbsence | Composition
+        ]
     },
     parameters={
         'delimiter': qiime2.plugin.Str,

--- a/q2_taxa/plugin_setup.py
+++ b/q2_taxa/plugin_setup.py
@@ -91,10 +91,10 @@ plugin.methods.register_function(
         ),
         'strict': (
             'Whether to parse the feature IDs in strict mode. If True, then '
-            'no occurences of semicolons are allowed in the feature IDs, all '
-            'IDs must contain `delimiter`, and no empty levels are allowed in '
-            'the converted taxonomic strings. If False, none of these '
-            'conditions are enforced.'
+            'no occurences of semicolons are allowed in the feature IDs, at '
+            'least one ID must contain `delimiter`, and no empty levels are '
+            'allowed in the converted taxonomic strings. If False, none of '
+            'these conditions are enforced.'
         ),
         'semicolon_replacement': (
             'The character to use to replace semicolons before replacing '

--- a/q2_taxa/plugin_setup.py
+++ b/q2_taxa/plugin_setup.py
@@ -113,10 +113,10 @@ plugin.methods.register_function(
             'column using the typical semicolon delimitation.'
         )
     },
-    name='Create taxonomy from hierarchical feature IDs.',
+    name='Create a taxonomy from hierarchical feature IDs in a feature table.',
     description=(
-        'This method converts feature IDs into taxonomy strings by splitting '
-        'IDs on a delimiter and joining levels with semicolons.'
+        'This method converts feature IDs in a feature table into a taxonomy '
+        'by splitting IDs on a delimiter and joining levels with semicolons.'
     )
 )
 

--- a/q2_taxa/plugin_setup.py
+++ b/q2_taxa/plugin_setup.py
@@ -16,8 +16,10 @@ from q2_types.feature_table import (
     Composition
 )
 
-from . import (barplot, barplot2, collapse, ids_to_taxonomy, filter_table,
-               filter_seqs)
+from . import (
+    barplot, barplot2, collapse, feature_ids_to_taxonomy, filter_table,
+    filter_seqs
+)
 import q2_taxa._examples as ex
 
 T1 = qiime2.plugin.TypeMatch([Frequency, PresenceAbsence])
@@ -69,7 +71,7 @@ plugin.methods.register_function(
 )
 
 plugin.methods.register_function(
-    function=ids_to_taxonomy,
+    function=feature_ids_to_taxonomy,
     inputs={
         'table': FeatureTable[
             Frequency | RelativeFrequency | PresenceAbsence | Composition

--- a/q2_taxa/tests/test_feature_ids_to_taxonomy.py
+++ b/q2_taxa/tests/test_feature_ids_to_taxonomy.py
@@ -22,7 +22,8 @@ class TestIdsToTaxonomy(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.ids_to_taxonomy = plugin.methods['ids_to_taxonomy']
+        cls.feature_ids_to_taxonomy = plugin.methods[
+            'feature_ids_to_taxonomy']
         cls.collapse = plugin.methods['collapse']
 
     def _make_table(self, feature_ids: list[str]):
@@ -38,7 +39,7 @@ class TestIdsToTaxonomy(unittest.TestCase):
         feature_ids = ['k|p|c', 'k2|p2|c2']
         table = self._make_table(feature_ids)
 
-        obs, = self.ids_to_taxonomy(table, delimiter='|', strict=True)
+        obs, = self.feature_ids_to_taxonomy(table, delimiter='|', strict=True)
         obs = obs.view(pd.DataFrame)
         exp = pd.DataFrame(
             {'Taxon': ['k;p;c', 'k2;p2;c2']},
@@ -56,7 +57,7 @@ class TestIdsToTaxonomy(unittest.TestCase):
         with self.assertRaisesRegex(
             ValueError, 'already contain ";".*1 feature IDs'
         ):
-            self.ids_to_taxonomy(table, delimiter='|')
+            self.feature_ids_to_taxonomy(table, delimiter='|')
 
     def test_strict_some_missing_delimiter_allowed(self):
         '''
@@ -67,7 +68,8 @@ class TestIdsToTaxonomy(unittest.TestCase):
         feature_ids = ['k|p|c', 'k']
         table = self._make_table(feature_ids)
 
-        obs, = self.ids_to_taxonomy(table, delimiter='|', strict=True)
+        obs, = self.feature_ids_to_taxonomy(
+            table, delimiter='|', strict=True)
         obs = obs.view(pd.DataFrame)
         exp = pd.DataFrame(
             {'Taxon': ['k;p;c', 'k']},
@@ -86,7 +88,7 @@ class TestIdsToTaxonomy(unittest.TestCase):
             ValueError,
             r'requires at least one feature ID to contain the delimiter \|'
         ):
-            self.ids_to_taxonomy(table, delimiter='|')
+            self.feature_ids_to_taxonomy(table, delimiter='|')
 
     def test_strict_empty_level_errors(self):
         '''
@@ -98,7 +100,7 @@ class TestIdsToTaxonomy(unittest.TestCase):
         with self.assertRaisesRegex(
                 ValueError, 'empty taxonomic levels.*1 feature IDs'
         ):
-            self.ids_to_taxonomy(table, delimiter='|')
+            self.feature_ids_to_taxonomy(table, delimiter='|')
 
     def test_non_strict(self):
         '''
@@ -111,7 +113,7 @@ class TestIdsToTaxonomy(unittest.TestCase):
         feature_ids = ['k|p;g|c', '|a||b|', 'k2']
         table = self._make_table(feature_ids)
 
-        obs, = self.ids_to_taxonomy(
+        obs, = self.feature_ids_to_taxonomy(
             table, delimiter='|', strict=False, semicolon_replacement=':')
         obs = obs.view(pd.DataFrame)
         exp = pd.DataFrame(
@@ -131,7 +133,7 @@ class TestIdsToTaxonomy(unittest.TestCase):
             ValueError,
             'Unable to construct non-empty taxonomy strings.*1 feature IDs'
         ):
-            self.ids_to_taxonomy(table, delimiter='|', strict=False)
+            self.feature_ids_to_taxonomy(table, delimiter='|', strict=False)
 
     def test_non_strict_empty_id_errors(self):
         '''
@@ -147,7 +149,7 @@ class TestIdsToTaxonomy(unittest.TestCase):
                 ValueError,
                 'Unable to construct non-empty taxonomy strings.*1 feature IDs'
         ):
-            self.ids_to_taxonomy(table, delimiter='|', strict=False)
+            self.feature_ids_to_taxonomy(table, delimiter='|', strict=False)
 
     def test_semicolon_replacement_not_provided_and_needed_errors(self):
         '''
@@ -160,7 +162,7 @@ class TestIdsToTaxonomy(unittest.TestCase):
             ValueError,
             r'semicolons detected.*"k;p\|c".*no `semicolon_replacement`'
         ):
-            self.ids_to_taxonomy(table, delimiter='|', strict=False)
+            self.feature_ids_to_taxonomy(table, delimiter='|', strict=False)
 
     def test_semicolon_replacement_is_semicolon_errors(self):
         '''
@@ -173,15 +175,15 @@ class TestIdsToTaxonomy(unittest.TestCase):
             ValueError,
             r'`semicolon_replacement` parameter can not be a semicolon'
         ):
-            self.ids_to_taxonomy(
+            self.feature_ids_to_taxonomy(
                 table, delimiter='|', semicolon_replacement=';', strict=False)
 
-    def test_ids_to_taxonomy_allows_collapse(self):
+    def test_feature_ids_to_taxonomy_allows_collapse(self):
         '''
-        Proves that we can use `ids_to_taxonomy` on a feature table where
-        we only have the taxonomy encoded in the feature ID labels to get a
-        taxonomy, and then use that taxonomy to collapse, which would not be
-        possible otherwise.
+        Proves that we can use `feature_ids_to_taxonomy` on a feature table
+        where we only have the taxonomy encoded in the feature ID labels to
+        get a taxonomy, and then use that taxonomy to collapse, which would
+        not be possible otherwise.
         '''
         table = Artifact.import_data(
             'FeatureTable[Frequency]',
@@ -190,7 +192,7 @@ class TestIdsToTaxonomy(unittest.TestCase):
                        ['s1', 's2'])
         )
 
-        taxonomy, = self.ids_to_taxonomy(table, delimiter='|')
+        taxonomy, = self.feature_ids_to_taxonomy(table, delimiter='|')
         collapsed, = self.collapse(taxonomy=taxonomy, table=table, level=2)
         obs = collapsed.view(biom.Table)
         obs.del_metadata()

--- a/q2_taxa/tests/test_ids_to_taxonomy.py
+++ b/q2_taxa/tests/test_ids_to_taxonomy.py
@@ -139,6 +139,34 @@ class TestIdsToTaxonomy(unittest.TestCase):
         ):
             ids_to_taxonomy(table, delimiter='|', strict=False)
 
+    def test_semicolon_replacement_not_provided_and_needed_errors(self):
+        '''
+        Ensures that in non-strict mode we error if semicolons are detected
+        in a feature ID and no `semicolon_replacement` was specified.
+        '''
+        table = self._make_table(['k;p|c', 'k|p|c2'])
+
+        with self.assertRaisesRegex(
+            ValueError,
+            r'semicolons detected.*"k;p\|c".*no `semicolon_replacement`'
+        ):
+            ids_to_taxonomy(table, delimiter='|', strict=False)
+
+    def test_semicolon_replacement_is_semicolon_errors(self):
+        '''
+        Ensures that in non-strict mode we error if semicolons are detected
+        in a feature ID and `semicolon_replacement` is set to ';'.
+        '''
+        table = self._make_table(['k;p|c', 'k|p|c2'])
+
+        with self.assertRaisesRegex(
+            ValueError,
+            r'`semicolon_replacement` parameter can not be a semicolon'
+        ):
+            ids_to_taxonomy(
+                table, delimiter='|', semicolon_replacement=';', strict=False
+            )
+
     def test_ids_to_taxonomy_allows_collapse(self):
         '''
         Proves that we can use `ids_to_taxonomy` on a feature table where

--- a/q2_taxa/tests/test_ids_to_taxonomy.py
+++ b/q2_taxa/tests/test_ids_to_taxonomy.py
@@ -48,17 +48,32 @@ class TestIdsToTaxonomy(unittest.TestCase):
         ):
             ids_to_taxonomy(table, delimiter='|')
 
-    def test_strict_missing_delimiter_errors(self):
+    def test_strict_some_missing_delimiter_allowed(self):
         '''
-        Ensure that with strict=True an error is raised when a feature ID
-        does not contain the delimiter.
+        Ensure that with strict=True we allow single-level taxonomy strings
+        that do not contain the delimiter, as long as at least one feature
+        ID contains the delimiter.
         '''
-        table = self._make_table(['k|p|c', 'k_p_c2'])
+        feature_ids = ['k|p|c', 'k']
+        table = self._make_table(feature_ids)
+
+        obs = ids_to_taxonomy(table, delimiter='|', strict=True)
+        exp = pd.DataFrame(
+            {'Taxon': ['k;p;c', 'k']},
+            index=pd.Index(feature_ids, name='Feature ID')
+        )
+        pdt.assert_frame_equal(obs, exp)
+
+    def test_strict_all_ids_missing_delimiter_errors(self):
+        '''
+        Ensure that with strict=True an error is raised when no feature ID
+        contains the delimiter.
+        '''
+        table = self._make_table(['k', 'p'])
 
         with self.assertRaisesRegex(
             ValueError,
-            r'requires every feature ID to contain the delimiter \|.*'
-            '1 feature IDs'
+            r'requires at least one feature ID to contain the delimiter \|'
         ):
             ids_to_taxonomy(table, delimiter='|')
 

--- a/q2_taxa/tests/test_ids_to_taxonomy.py
+++ b/q2_taxa/tests/test_ids_to_taxonomy.py
@@ -1,0 +1,145 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016-2025, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
+import unittest
+
+import biom
+import numpy as np
+import pandas as pd
+import pandas.testing as pdt
+
+from q2_taxa import collapse, ids_to_taxonomy
+
+
+class TestIdsToTaxonomy(unittest.TestCase):
+    def _make_table(self, feature_ids: list[str]):
+        data = np.arange(1, len(feature_ids) + 1).reshape(len(feature_ids), 1)
+        return biom.Table(data, feature_ids, ['sample-1'])
+
+    def test_strict(self):
+        '''
+        Ensure that with strict=True a non-default delimiter parsing works
+        as expected.
+        '''
+        feature_ids = ['k|p|c', 'k2|p2|c2']
+        table = self._make_table(feature_ids)
+
+        obs = ids_to_taxonomy(table, delimiter='|', strict=True)
+        exp = pd.DataFrame(
+            {'Taxon': ['k;p;c', 'k2;p2;c2']},
+            index=pd.Index(feature_ids, name='Feature ID')
+        )
+        pdt.assert_frame_equal(obs, exp)
+
+    def test_strict_semicolon_present_errors(self):
+        '''
+        Ensure that with strict=True an error is raised when a semicolon
+        is present in a feature ID.
+        '''
+        table = self._make_table(['k|p;g|c', 'k|p|c'])
+
+        with self.assertRaisesRegex(
+            ValueError, 'already contain ";".*1 feature IDs'
+        ):
+            ids_to_taxonomy(table, delimiter='|')
+
+    def test_strict_missing_delimiter_errors(self):
+        '''
+        Ensure that with strict=True an error is raised when a feature ID
+        does not contain the delimiter.
+        '''
+        table = self._make_table(['k|p|c', 'k_p_c2'])
+
+        with self.assertRaisesRegex(
+            ValueError,
+            r'requires every feature ID to contain the delimiter \|.*'
+            '1 feature IDs'
+        ):
+            ids_to_taxonomy(table, delimiter='|')
+
+    def test_strict_empty_level_errors(self):
+        '''
+        Ensure that with strict=True an error is raised when a feature ID
+        parses in such a way that an empty level is created.
+        '''
+        table = self._make_table(['k||c', 'k|p|c'])
+
+        with self.assertRaisesRegex(
+                ValueError, 'empty taxonomic levels.*1 feature IDs'
+        ):
+            ids_to_taxonomy(table, delimiter='|')
+
+    def test_non_strict(self):
+        '''
+        Tests a non-strict parsing with semicolons present, empty levels,
+        and missing delimiters by ensuring we:
+            - replace the semicolon with the proper replacement
+            - collapse away empty levels
+            - retain delimiter-missing labels
+        '''
+        feature_ids = ['k|p;g|c', '|a||b|', 'k2']
+        table = self._make_table(feature_ids)
+
+        obs = ids_to_taxonomy(
+            table, delimiter='|', strict=False, semicolon_replacement=':'
+        )
+        exp = pd.DataFrame(
+            {'Taxon': ['k;p:g;c', 'a;b', 'k2']},
+            index=pd.Index(feature_ids, name='Feature ID')
+        )
+
+        pdt.assert_frame_equal(obs, exp)
+
+    def test_non_strict_id_with_only_delimiters_errors(self):
+        '''
+        Ensures that in non-strict mode we error when a feature ID containing
+        only delimiters parses into an empty taxonomic string.
+        '''
+        table = self._make_table(['||', 'k|p|c'])
+
+        with self.assertRaisesRegex(
+            ValueError,
+            'Unable to construct non-empty taxonomy strings.*1 feature IDs'
+        ):
+            ids_to_taxonomy(table, delimiter='|', strict=False)
+
+    def test_non_strict_empty_id_errors(self):
+        '''
+        Ensures that in non-strict mode we error when an empty feature ID
+        only parses into an empty taxonomic string.
+
+        (Note: we need coverage of this because biom.Table does not disallow
+        empty strings as feature IDs, only uniqueness among IDs.)
+        '''
+        table = self._make_table(['', 'k|p|c'])
+
+        with self.assertRaisesRegex(
+                ValueError,
+                'Unable to construct non-empty taxonomy strings.*1 feature IDs'
+        ):
+            ids_to_taxonomy(table, delimiter='|', strict=False)
+
+    def test_ids_to_taxonomy_allows_collapse(self):
+        '''
+        Proves that we can use `ids_to_taxonomy` on a feature table where
+        we only have the taxonomy encoded in the feature ID labels to get a
+        taxonomy, and then use that taxonomy to collapse, which would not be
+        possible otherwise.
+        '''
+        table = biom.Table(
+            np.array([[1.0, 2.0], [3.0, 4.0]]),
+            ['k|p|c', 'k|p|g'],
+            ['s1', 's2']
+        )
+
+        taxonomy = ids_to_taxonomy(table, delimiter='|')
+        obs = collapse(table, taxonomy['Taxon'], level=2)
+        obs.del_metadata()
+
+        exp = biom.Table(np.array([[4.0, 6.0]]), ['k;p'], ['s1', 's2'])
+        self.assertEqual(obs, exp)

--- a/q2_taxa/tests/test_ids_to_taxonomy.py
+++ b/q2_taxa/tests/test_ids_to_taxonomy.py
@@ -13,13 +13,22 @@ import numpy as np
 import pandas as pd
 import pandas.testing as pdt
 
-from q2_taxa import collapse, ids_to_taxonomy
+from qiime2 import Artifact
+from q2_taxa.plugin_setup import plugin
 
 
 class TestIdsToTaxonomy(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.ids_to_taxonomy = plugin.methods['ids_to_taxonomy']
+        cls.collapse = plugin.methods['collapse']
+
     def _make_table(self, feature_ids: list[str]):
         data = np.arange(1, len(feature_ids) + 1).reshape(len(feature_ids), 1)
-        return biom.Table(data, feature_ids, ['sample-1'])
+        table = biom.Table(data, feature_ids, ['sample-1'])
+        return Artifact.import_data('FeatureTable[Frequency]', table)
 
     def test_strict(self):
         '''
@@ -29,7 +38,8 @@ class TestIdsToTaxonomy(unittest.TestCase):
         feature_ids = ['k|p|c', 'k2|p2|c2']
         table = self._make_table(feature_ids)
 
-        obs = ids_to_taxonomy(table, delimiter='|', strict=True)
+        obs, = self.ids_to_taxonomy(table, delimiter='|', strict=True)
+        obs = obs.view(pd.DataFrame)
         exp = pd.DataFrame(
             {'Taxon': ['k;p;c', 'k2;p2;c2']},
             index=pd.Index(feature_ids, name='Feature ID')
@@ -46,7 +56,7 @@ class TestIdsToTaxonomy(unittest.TestCase):
         with self.assertRaisesRegex(
             ValueError, 'already contain ";".*1 feature IDs'
         ):
-            ids_to_taxonomy(table, delimiter='|')
+            self.ids_to_taxonomy(table, delimiter='|')
 
     def test_strict_some_missing_delimiter_allowed(self):
         '''
@@ -57,7 +67,8 @@ class TestIdsToTaxonomy(unittest.TestCase):
         feature_ids = ['k|p|c', 'k']
         table = self._make_table(feature_ids)
 
-        obs = ids_to_taxonomy(table, delimiter='|', strict=True)
+        obs, = self.ids_to_taxonomy(table, delimiter='|', strict=True)
+        obs = obs.view(pd.DataFrame)
         exp = pd.DataFrame(
             {'Taxon': ['k;p;c', 'k']},
             index=pd.Index(feature_ids, name='Feature ID')
@@ -75,7 +86,7 @@ class TestIdsToTaxonomy(unittest.TestCase):
             ValueError,
             r'requires at least one feature ID to contain the delimiter \|'
         ):
-            ids_to_taxonomy(table, delimiter='|')
+            self.ids_to_taxonomy(table, delimiter='|')
 
     def test_strict_empty_level_errors(self):
         '''
@@ -87,7 +98,7 @@ class TestIdsToTaxonomy(unittest.TestCase):
         with self.assertRaisesRegex(
                 ValueError, 'empty taxonomic levels.*1 feature IDs'
         ):
-            ids_to_taxonomy(table, delimiter='|')
+            self.ids_to_taxonomy(table, delimiter='|')
 
     def test_non_strict(self):
         '''
@@ -100,14 +111,13 @@ class TestIdsToTaxonomy(unittest.TestCase):
         feature_ids = ['k|p;g|c', '|a||b|', 'k2']
         table = self._make_table(feature_ids)
 
-        obs = ids_to_taxonomy(
-            table, delimiter='|', strict=False, semicolon_replacement=':'
-        )
+        obs, = self.ids_to_taxonomy(
+            table, delimiter='|', strict=False, semicolon_replacement=':')
+        obs = obs.view(pd.DataFrame)
         exp = pd.DataFrame(
             {'Taxon': ['k;p:g;c', 'a;b', 'k2']},
             index=pd.Index(feature_ids, name='Feature ID')
         )
-
         pdt.assert_frame_equal(obs, exp)
 
     def test_non_strict_id_with_only_delimiters_errors(self):
@@ -121,7 +131,7 @@ class TestIdsToTaxonomy(unittest.TestCase):
             ValueError,
             'Unable to construct non-empty taxonomy strings.*1 feature IDs'
         ):
-            ids_to_taxonomy(table, delimiter='|', strict=False)
+            self.ids_to_taxonomy(table, delimiter='|', strict=False)
 
     def test_non_strict_empty_id_errors(self):
         '''
@@ -137,7 +147,7 @@ class TestIdsToTaxonomy(unittest.TestCase):
                 ValueError,
                 'Unable to construct non-empty taxonomy strings.*1 feature IDs'
         ):
-            ids_to_taxonomy(table, delimiter='|', strict=False)
+            self.ids_to_taxonomy(table, delimiter='|', strict=False)
 
     def test_semicolon_replacement_not_provided_and_needed_errors(self):
         '''
@@ -150,7 +160,7 @@ class TestIdsToTaxonomy(unittest.TestCase):
             ValueError,
             r'semicolons detected.*"k;p\|c".*no `semicolon_replacement`'
         ):
-            ids_to_taxonomy(table, delimiter='|', strict=False)
+            self.ids_to_taxonomy(table, delimiter='|', strict=False)
 
     def test_semicolon_replacement_is_semicolon_errors(self):
         '''
@@ -163,9 +173,8 @@ class TestIdsToTaxonomy(unittest.TestCase):
             ValueError,
             r'`semicolon_replacement` parameter can not be a semicolon'
         ):
-            ids_to_taxonomy(
-                table, delimiter='|', semicolon_replacement=';', strict=False
-            )
+            self.ids_to_taxonomy(
+                table, delimiter='|', semicolon_replacement=';', strict=False)
 
     def test_ids_to_taxonomy_allows_collapse(self):
         '''
@@ -174,14 +183,16 @@ class TestIdsToTaxonomy(unittest.TestCase):
         taxonomy, and then use that taxonomy to collapse, which would not be
         possible otherwise.
         '''
-        table = biom.Table(
-            np.array([[1.0, 2.0], [3.0, 4.0]]),
-            ['k|p|c', 'k|p|g'],
-            ['s1', 's2']
+        table = Artifact.import_data(
+            'FeatureTable[Frequency]',
+            biom.Table(np.array([[1.0, 2.0], [3.0, 4.0]]),
+                       ['k|p|c', 'k|p|g'],
+                       ['s1', 's2'])
         )
 
-        taxonomy = ids_to_taxonomy(table, delimiter='|')
-        obs = collapse(table, taxonomy['Taxon'], level=2)
+        taxonomy, = self.ids_to_taxonomy(table, delimiter='|')
+        collapsed, = self.collapse(taxonomy=taxonomy, table=table, level=2)
+        obs = collapsed.view(biom.Table)
         obs.del_metadata()
 
         exp = biom.Table(np.array([[4.0, 6.0]]), ['k;p'], ['s1', 's2'])


### PR DESCRIPTION
Adds a new action, `ids-to-taxonomy`, that generates a semicolon-delimited taxonomy from feature IDs in a feature table that (hopefully) encode taxonomic levels.